### PR TITLE
Fix course switcher removeChild crash

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -398,12 +398,16 @@
     if (!contentArea) return; // Children not rendered yet — retry on next mutation
     handledPopovers.add(popover);
 
-    // Hide Ultra's original children instead of destroying them —
-    // React still owns these nodes and must be able to reconcile them.
-    for (const child of contentArea.children) {
-      child.style.display = "none";
-    }
+    // Preserve Ultra's DOM so React can still reconcile, but occlude it
+    // with the extension's UI. Using position/overflow instead of hiding
+    // individual children avoids a race where late-rendering React nodes
+    // escape a display:none pass on first open.
+    contentArea.style.position = "relative";
+    contentArea.style.overflow = "hidden";
     const extContainer = document.createElement("div");
+    extContainer.style.position = "relative";
+    extContainer.style.zIndex = "1";
+    extContainer.style.background = "inherit";
     contentArea.appendChild(extContainer);
     buildDropdownUI(extContainer, courses);
   }

--- a/courses.js
+++ b/courses.js
@@ -276,7 +276,6 @@
 
   // === UI Layer ===
   function buildDropdownUI(container, courses) {
-    container.innerHTML = "";
     const hidden = loadHidden();
 
     const search = document.createElement("input");
@@ -398,7 +397,15 @@
     if (contentArea) contentArea = contentArea.parentElement;
     if (!contentArea) return; // Children not rendered yet — retry on next mutation
     handledPopovers.add(popover);
-    buildDropdownUI(contentArea, courses);
+
+    // Hide Ultra's original children instead of destroying them —
+    // React still owns these nodes and must be able to reconcile them.
+    for (const child of contentArea.children) {
+      child.style.display = "none";
+    }
+    const extContainer = document.createElement("div");
+    contentArea.appendChild(extContainer);
+    buildDropdownUI(extContainer, courses);
   }
 
   function scanForPopover() {

--- a/courses.js
+++ b/courses.js
@@ -127,6 +127,9 @@
       .${P}-item-hidden .${P}-vis-btn {
         opacity: 0.5;
       }
+      .${P}-content-area > *:not(.${P}-container) {
+        display: none !important;
+      }
     `;
     (document.head || document.documentElement).appendChild(style);
   }
@@ -398,16 +401,12 @@
     if (!contentArea) return; // Children not rendered yet — retry on next mutation
     handledPopovers.add(popover);
 
-    // Preserve Ultra's DOM so React can still reconcile, but occlude it
-    // with the extension's UI. Using position/overflow instead of hiding
-    // individual children avoids a race where late-rendering React nodes
-    // escape a display:none pass on first open.
-    contentArea.style.position = "relative";
-    contentArea.style.overflow = "hidden";
+    // Hide Ultra's children via CSS class selector rather than iterating
+    // them individually — the rule applies continuously, so late-rendering
+    // React nodes are hidden automatically (no race condition on first open).
+    contentArea.classList.add(P + "-content-area");
     const extContainer = document.createElement("div");
-    extContainer.style.position = "relative";
-    extContainer.style.zIndex = "1";
-    extContainer.style.background = "inherit";
+    extContainer.classList.add(P + "-container");
     contentArea.appendChild(extContainer);
     buildDropdownUI(extContainer, courses);
   }


### PR DESCRIPTION
## Summary
- The course switcher wiped Ultra's React-managed DOM with `innerHTML = ""`, causing a `NotFoundError` when React tried to reconcile its virtual tree.
- Instead of destroying Ultra's nodes, the fix hides them via CSS (`display: none`) and renders the extension's UI in a fresh sibling container. React's DOM tree stays intact.

## Changes
- `handlePopover()`: hide existing children of `contentArea` instead of passing it to be wiped; create a new extension-owned container for the UI.
- `buildDropdownUI()`: remove the `innerHTML = ""` line (container is now always fresh).

## Test plan
- [ ] Click the course switcher button — the extension's enhanced list should appear with no error modal
- [ ] Verify search, filtering, and course click-through all work as before
- [ ] Open and close the popover multiple times — no stale UI or duplicate content
- [ ] Navigate away and back via SPA routing, then reopen the popover — still works
- [ ] Check browser console for `removeChild` or `NotFoundError` — should be clean